### PR TITLE
Fix kernel 6.13+ compatibility: replace `del_timer_sync` by `timer_delete_sync`

### DIFF
--- a/linux/drivers/hid/hid-magicmouse.c
+++ b/linux/drivers/hid/hid-magicmouse.c
@@ -899,7 +899,7 @@ static int magicmouse_fetch_battery(struct hid_device *hdev)
 
 static void magicmouse_battery_timer_tick(struct timer_list *t)
 {
-	struct magicmouse_sc *msc = from_timer(msc, t, battery_timer);
+	struct magicmouse_sc *msc = container_of(t, struct magicmouse_sc, battery_timer);
 	struct hid_device *hdev = msc->hdev;
 
 	if (magicmouse_fetch_battery(hdev) == 0) {


### PR DESCRIPTION
- Add missing #include <linux/timer.h> header
- Replace deprecated del_timer_sync() with timer_delete_sync() for kernel 6.13+
- Add version-specific conditional compilation for backward compatibility
- Fixes compilation errors on newer kernels like 6.15.2